### PR TITLE
ci: add CI/CD workflows and documentation

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,44 @@
+name: CD
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - name: Publish to pub.dev
+        run: dart pub publish --force
+
+  github-release:
+    runs-on: ubuntu-latest
+    needs: publish
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+      - name: Extract changelog notes
+        id: changelog
+        run: |
+          # Extract the section for this version from CHANGELOG.md
+          NOTES=$(awk '/^## \[?'"$VERSION"'\]?/{found=1; next} /^## /{if(found) exit} found{print}' CHANGELOG.md)
+          echo "NOTES<<EOF" >> $GITHUB_OUTPUT
+          echo "$NOTES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+      - uses: softprops/action-gh-release@v2
+        with:
+          name: v${{ env.VERSION }}
+          body: ${{ steps.changelog.outputs.NOTES }}
+          make_latest: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [production]
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - run: flutter analyze
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - run: dart format --set-exit-if-changed .
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - run: flutter test --coverage
+      - uses: codecov/codecov-action@v4
+        with:
+          files: coverage/lcov.info
+          fail_ci_if_error: false
+
+  dry-run-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - run: flutter pub publish --dry-run

--- a/doc/ci-cd-overview.md
+++ b/doc/ci-cd-overview.md
@@ -1,0 +1,67 @@
+# CI/CD Overview
+
+## 1. What checks are in the CI/CD pipeline?
+
+### CI (Continuous Integration) — `ci.yml`
+
+| Check | What it does |
+|-------|-------------|
+| **analyze** | Runs `flutter analyze` to catch lint warnings, type errors, and style violations defined in `analysis_options.yaml`. |
+| **format** | Runs `dart format --set-exit-if-changed .` to ensure all Dart code follows the standard Dart formatting rules. Fails if any file is not properly formatted. |
+| **test** | Runs `flutter test --coverage` to execute all unit tests and generate a coverage report. Uploads coverage data to Codecov. |
+| **dry-run-publish** | Runs `flutter pub publish --dry-run` to verify the package is in a valid, publishable state (correct pubspec, no missing files, etc.) without actually publishing. |
+
+### CD (Continuous Deployment) — `cd.yml`
+
+| Check | What it does |
+|-------|-------------|
+| **publish** | Runs `dart pub publish --force` to publish the package to pub.dev using the stored authentication token. |
+| **github-release** | Extracts the latest version's notes from `CHANGELOG.md` and creates a GitHub Release with those notes. Runs only after `publish` succeeds. |
+
+---
+
+## 2. When does CI run?
+
+CI runs automatically on:
+
+- **Every pull request** targeting the `production` branch
+
+This means every change gets validated before it can be merged into `production`.
+
+---
+
+## 3. When does CD run?
+
+CD runs **only** when a git tag matching `v*` is pushed. For example:
+
+```bash
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+This triggers the publish to pub.dev and the GitHub Release creation. Merging to `production` alone does **not** trigger a publish — you must explicitly tag a release.
+
+---
+
+## 4. How many checks run?
+
+| Trigger | Number of checks | Checks |
+|---------|-----------------|--------|
+| PR to `production` | 4 | analyze, format, test, dry-run-publish |
+| Push a `v*` tag | 2 | publish, github-release |
+
+All 4 CI checks run in parallel. In the CD pipeline, `github-release` runs sequentially after `publish` succeeds.
+
+---
+
+## 5. Branch protection rules
+
+The following rules are applied to the `production` branch in GitHub Settings:
+
+| Rule | Why | When it applies |
+|------|-----|-----------------|
+| **Require a pull request before merging** | Prevents direct pushes to `production`. All changes must go through a PR, providing a clear review trail and ensuring CI runs before merge. | Every time someone tries to push or merge into `production`. |
+| **Require status checks to pass** (`analyze`, `format`, `test`) | Ensures no broken, unformatted, or failing code reaches `production`. The three checks must all pass before the PR merge button becomes available. | When a PR targets `production` — GitHub blocks the merge until all three checks are green. |
+| **Require branches to be up to date before merging** | Ensures the PR has been tested against the latest `production` code, not a stale version. Prevents cases where two PRs pass individually but conflict when both are merged. | When merging a PR — if `production` has moved ahead since the branch was last updated, you must update your branch first. |
+| **Do not allow force pushes** | Protects the commit history of `production` from being rewritten. Force pushes can destroy commits and break other contributors' branches. | Any time someone attempts `git push --force` to `production`. |
+| **Do not allow deletions** | Prevents accidental or intentional deletion of the `production` branch. | Any time someone attempts to delete the `production` branch. |

--- a/example/integration_test/plugin_integration_test.dart
+++ b/example/integration_test/plugin_integration_test.dart
@@ -6,7 +6,6 @@
 // For more information about Flutter integration tests, please see
 // https://flutter.dev/to/integration-testing
 
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -18,8 +18,8 @@ void main() {
     // Verify that platform version is retrieved.
     expect(
       find.byWidgetPredicate(
-        (Widget widget) => widget is Text &&
-                           widget.data!.startsWith('Running on:'),
+        (Widget widget) =>
+            widget is Text && widget.data!.startsWith('Running on:'),
       ),
       findsOneWidget,
     );


### PR DESCRIPTION
## Summary
- Add CI workflow (`ci.yml`) with 4 parallel checks: analyze, format, test (with Codecov), and dry-run-publish — runs on PRs to `production`
- Add CD workflow (`cd.yml`) with publish to pub.dev and GitHub Release creation — triggers on `v*` tags
- Add `doc/ci-cd-overview.md` documenting the pipeline, triggers, and branch protection rules

## Test plan
- [x] Verify CI runs on this PR (analyze, format, test, dry-run-publish)
- [x] Configure branch protection rules on `production` as described in `doc/ci-cd-overview.md`