### PR TITLE
chore: prepare v1.0.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,10 @@
+## 1.0.4
+
+- Added Swift Package Manager (SPM) support for iOS while maintaining CocoaPods backward compatibility
+- Restructured iOS plugin sources into SPM-compatible directory layout
+- Updated podspec metadata (version, summary, description, homepage, author)
+- Enabled PrivacyInfo.xcprivacy resource bundle
+- Fixed iOS unit tests to match actual plugin API
+- Shortened package description to meet pub.dev requirements
+
 ## 1.0.3

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Flutter plugin to display an **in-app update prompt for iOS** using the **App 
 
 - ✅ Show in-app update prompt using `SKStoreProductViewController`
 - ✅ Native Swift implementation
+- ✅ Supports both Swift Package Manager (SPM) and CocoaPods
 - ✅ No manual setup required in iOS AppDelegate
 - ✅ Pass dynamic App Store ID via MethodChannel
 - ✅ Works directly from Flutter with a single call

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
-group = "com.example.in_app_update_flutter"
+group = "tech.axions.in_app_update_flutter"
 version = "1.0-SNAPSHOT"
 
 buildscript {
@@ -25,7 +25,7 @@ apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
 android {
-    namespace = "com.example.in_app_update_flutter"
+    namespace = "tech.axions.in_app_update_flutter"
 
     compileSdk = 35
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.example.in_app_update_flutter">
+  package="tech.axions.in_app_update_flutter">
 </manifest>

--- a/android/src/main/kotlin/tech/axions/in_app_update_flutter/InAppUpdateFlutterPlugin.kt
+++ b/android/src/main/kotlin/tech/axions/in_app_update_flutter/InAppUpdateFlutterPlugin.kt
@@ -1,4 +1,4 @@
-package com.example.in_app_update_flutter
+package tech.axions.in_app_update_flutter
 
 import androidx.annotation.NonNull
 

--- a/android/src/test/kotlin/tech/axions/in_app_update_flutter/InAppUpdateFlutterPluginTest.kt
+++ b/android/src/test/kotlin/tech/axions/in_app_update_flutter/InAppUpdateFlutterPluginTest.kt
@@ -1,4 +1,4 @@
-package com.example.in_app_update_flutter
+package tech.axions.in_app_update_flutter
 
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel

--- a/ios/in_app_update_flutter.podspec
+++ b/ios/in_app_update_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'in_app_update_flutter'
-  s.version          = '1.0.3'
+  s.version          = '1.0.4'
   s.summary          = 'Show an in-app update prompt using the native App Store product page.'
   s.description      = <<-DESC
 A Flutter plugin to show an in-app update prompt using the native App Store product page on iOS, keeping users inside your app.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: in_app_update_flutter
 description: "A Flutter plugin to show an in-app update prompt using the native App Store product page on iOS, keeping users inside your app."
-version: 1.0.3
+version: 1.0.4
 repository: https://github.com/pulkit7724/in_app_update_flutter.git
 
 environment:
@@ -21,7 +21,7 @@ flutter:
   plugin:
     platforms:
       android:
-        package: com.example.in_app_update_flutter
+        package: tech.axions.in_app_update_flutter
         pluginClass: InAppUpdateFlutterPlugin
       ios:
         pluginClass: InAppUpdateFlutterPlugin


### PR DESCRIPTION
## Summary
- Bump version to 1.0.4 across pubspec.yaml, podspec, and changelog
- Rename Android package from `com.example.in_app_update_flutter` to `tech.axions.in_app_update_flutter`
- Add SPM support to README features list
- Add detailed changelog entries for all v1.0.4 changes

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 8/8 passed
- [x] `dart format --set-exit-if-changed .` — no changes needed
- [x] `flutter pub publish --dry-run` — passes validation