### PR TITLE
release: v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 2.0.0
+
+- Added Android in-app updates support via Google Play's In-App Updates API
+- Added `checkUpdateAndroid()` to retrieve update availability and metadata
+- Added `startImmediateUpdateAndroid()` for full-screen, blocking update flow
+- Added `startFlexibleUpdateAndroid()` for background download update flow
+- Added `completeUpdateAndroid()` to apply a downloaded flexible update
+- Added `installStateStreamAndroid` stream for monitoring flexible update download progress
+- Added `AppUpdateInfoAndroid`, `InstallStateAndroid`, `InstallStatusAndroid`, `UpdateAvailabilityAndroid`, and `UpdateResultAndroid` models
+- Renamed `showUpdate()` to `showUpdateForIos()` (old method is deprecated)
+- Updated Android toolchain to latest stable versions
+
 ## 1.0.4
 
 - Added Swift Package Manager (SPM) support for iOS while maintaining CocoaPods backward compatibility

--- a/README.md
+++ b/README.md
@@ -1,27 +1,31 @@
-# 📦 in_app_update_flutter
+# in_app_update_flutter
 
-A Flutter plugin to display an **in-app update prompt for iOS** using the **App Store product page**. This avoids navigating the user out of your app, providing a seamless and native update experience.
+A Flutter plugin for in-app updates on both iOS and Android.
 
----
-
-## ✨ Features
-
-- ✅ Show in-app update prompt using `SKStoreProductViewController`
-- ✅ Native Swift implementation
-- ✅ Supports both Swift Package Manager (SPM) and CocoaPods
-- ✅ No manual setup required in iOS AppDelegate
-- ✅ Pass dynamic App Store ID via MethodChannel
-- ✅ Works directly from Flutter with a single call
+On **iOS**, it presents the App Store product page using `SKStoreProductViewController` (StoreKit), keeping users inside the app during the update flow. On **Android**, it integrates with Google Play's In-App Updates API to support both immediate (blocking) and flexible (background) update flows.
 
 ---
 
-## 🛠 Installation
+## Features
+
+- iOS: Show the App Store update prompt using `SKStoreProductViewController` without navigating users away from the app
+- iOS: Native Swift implementation with zero AppDelegate configuration required
+- iOS: Supports both Swift Package Manager (SPM) and CocoaPods
+- Android: Check update availability and metadata via the Play Core API
+- Android: Immediate update flow — full-screen, blocking prompt the user must accept
+- Android: Flexible update flow — background download while the user continues using the app
+- Android: Install state stream for monitoring flexible update download progress
+- Works on Flutter with a simple, unified API
+
+---
+
+## Installation
 
 Add the package to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  in_app_update_flutter: ^1.0.0
+  in_app_update_flutter: ^2.0.0
 ```
 
 Then run:
@@ -32,40 +36,91 @@ flutter pub get
 
 ---
 
-## 🚀 Usage
+## iOS Usage
+
+Pass your numeric App Store ID to `showUpdateForIos`. The ID can be found in your App Store Connect URL or the app's public App Store link.
 
 ```dart
 import 'package:in_app_update_flutter/in_app_update_flutter.dart';
 
-await InAppUpdateFlutter().showUpdate(appStoreId: '1234567890');
+await InAppUpdateFlutter().showUpdateForIos(appStoreId: '1234567890');
 ```
 
-Make sure to pass your App Store ID (from the app’s public iTunes URL).
+**How to find your App Store ID:**
+
+1. Open your app's App Store URL — for example: `https://apps.apple.com/app/id1234567890`
+2. The numeric portion after `id` is your App Store ID.
+
+**iOS notes:**
+- Requires iOS 12.0 or later
+- Does not work on simulators
+- Not supported in TestFlight builds — test on a real device using a development or App Store build
 
 ---
 
-## 🔍 How to Get Your App Store ID
+## Android Usage
 
-1. Go to your app’s App Store URL  
-   Example: `https://apps.apple.com/app/id1234567890`
-2. Extract the numeric ID (without the `id` prefix)
-3. Pass it like this:
+Android uses Google Play's In-App Updates API. The typical flow is:
+
+1. Call `checkUpdateAndroid()` to retrieve update availability and metadata.
+2. Based on the result, start either an immediate or flexible update.
+
+### Immediate Update
+
+An immediate update presents a full-screen prompt that the user must complete before continuing. Use this for critical updates.
 
 ```dart
-await InAppUpdateFlutter().showUpdate(appStoreId: "1234567890");
+import 'package:in_app_update_flutter/in_app_update_flutter.dart';
+
+final plugin = InAppUpdateFlutter();
+
+final info = await plugin.checkUpdateAndroid();
+
+if (info.updateAvailability == UpdateAvailabilityAndroid.updateAvailable &&
+    info.isImmediateUpdateAllowed) {
+  final result = await plugin.startImmediateUpdateAndroid();
+  // result is UpdateResultAndroid.success or UpdateResultAndroid.userCanceled
+}
 ```
 
+### Flexible Update
+
+A flexible update downloads in the background while the user continues using the app. When the download completes, call `completeUpdateAndroid()` to apply the update.
+
+```dart
+import 'package:in_app_update_flutter/in_app_update_flutter.dart';
+
+final plugin = InAppUpdateFlutter();
+
+final info = await plugin.checkUpdateAndroid();
+
+if (info.updateAvailability == UpdateAvailabilityAndroid.updateAvailable &&
+    info.isFlexibleUpdateAllowed) {
+  await plugin.startFlexibleUpdateAndroid();
+
+  plugin.installStateStreamAndroid.listen((state) {
+    if (state.installStatus == InstallStatusAndroid.downloaded) {
+      plugin.completeUpdateAndroid();
+    }
+  });
+}
+```
+
+### AppUpdateInfoAndroid fields
+
+| Field | Type | Description |
+|---|---|---|
+| `updateAvailability` | `UpdateAvailabilityAndroid` | Whether an update is available |
+| `availableVersionCode` | `int?` | Version code of the available update |
+| `updatePriority` | `int` | Developer-assigned priority (0–5) |
+| `clientVersionStalenessDays` | `int?` | Days since the update became available |
+| `isImmediateUpdateAllowed` | `bool` | Whether immediate update is allowed |
+| `isFlexibleUpdateAllowed` | `bool` | Whether flexible update is allowed |
+| `installStatus` | `InstallStatusAndroid` | Current install status |
+
 ---
 
-## 📱 iOS Notes
-
-- ✅ Supports iOS 12.0+
-- ❌ Does **not work on simulators**
-- ❌ Not supported in **TestFlight** builds (use App Store or dev builds on real devices)
-
----
-
-## ✅ Example
+## Example
 
 A complete working example is available in the [`example/`](example) directory.
 
@@ -76,19 +131,12 @@ flutter run
 
 ---
 
-## 📦 Publisher
-
-Published by [pulkit.sh](https://pub.dev/publishers/pulkit.sh)
-
----
-
-## 📄 License
+## License
 
 [MIT License](LICENSE)
 
 ---
 
-## 🤝 Contributing
+## Contributing
 
-Pull requests and feedback are welcome!  
-For major changes, please open an issue first to discuss what you’d like to change.
+Pull requests and feedback are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/ios/in_app_update_flutter.podspec
+++ b/ios/in_app_update_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'in_app_update_flutter'
-  s.version          = '1.0.4'
+  s.version          = '2.0.0'
   s.summary          = 'Show an in-app update prompt using the native App Store product page.'
   s.description      = <<-DESC
 A Flutter plugin to show an in-app update prompt using the native App Store product page on iOS, keeping users inside your app.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: in_app_update_flutter
 description: "A Flutter plugin to show an in-app update prompt using the native App Store product page on iOS, keeping users inside your app."
-version: 1.0.4
+version: 2.0.0
 repository: https://github.com/pulkit7724/in_app_update_flutter.git
 
 environment:


### PR DESCRIPTION
## Summary

- Bumps version to `2.0.0` in `pubspec.yaml` and `ios/in_app_update_flutter.podspec`
- Rewrites `README.md`: removes emojis, removes publisher section, adds full Android usage documentation with immediate and flexible update examples and API reference table
- Adds `## 2.0.0` entry to `CHANGELOG.md` documenting all Android additions, the `showUpdateForIos` rename, and toolchain updates

## Test plan

- [ ] Verify `flutter pub publish --dry-run` passes
- [ ] Confirm iOS update flow works on a real device
- [ ] Confirm Android immediate and flexible update flows work against a Play Store track

🤖 Generated with [Claude Code](https://claude.com/claude-code)