### PR TITLE
feat: add iOS bundle ID support for in-app update prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.1.0
+
+- Added `showStoreUpdateIosByBundleId()` — resolves the App Store ID from a bundle ID via the iTunes Lookup API and presents the App Store update prompt
+- Added `showStoreUpdateIosByAppStoreId()` — explicit replacement for `showUpdateForIos()`, which is now deprecated
+- Fixed iOS production safety issues: removed retained `flutterResult` and `controller` instance variables, pass `result` through the call chain to support concurrent calls safely
+- Fixed iOS: `topViewController()` resolves the topmost presented view controller at call time instead of capturing root at registration
+- Fixed iOS: added `[weak self]` and `DispatchQueue.main.async` to `loadProduct` closure to prevent retain cycle and guarantee UI calls on the main thread
+- Fixed Android: explicitly unregister `InstallStateUpdatedListener` in `unregisterActivityListener()` to prevent listener leak on abrupt activity detach
+
 ## 2.0.0
 
 - Added Android in-app updates support via Google Play's In-App Updates API

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ On **iOS**, it presents the App Store product page using `SKStoreProductViewCont
 
 ## Features
 
-- iOS: Show the App Store update prompt using `SKStoreProductViewController` without navigating users away from the app
+- iOS: Show the App Store update prompt using `SKStoreProductViewController` without navigating users away from the app, via App Store ID or bundle ID
 - iOS: Native Swift implementation with zero AppDelegate configuration required
 - iOS: Supports both Swift Package Manager (SPM) and CocoaPods
 - Android: Check update availability and metadata via the Play Core API
@@ -25,7 +25,7 @@ Add the package to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  in_app_update_flutter: ^2.0.0
+  in_app_update_flutter: ^2.1.0
 ```
 
 Then run:
@@ -38,18 +38,51 @@ flutter pub get
 
 ## iOS Usage
 
-Pass your numeric App Store ID to `showUpdateForIos`. The ID can be found in your App Store Connect URL or the app's public App Store link.
+There are two ways to trigger the App Store update prompt on iOS.
+
+### Option 1: Using the App Store ID (recommended)
+
+Pass the numeric App Store ID directly. This requires no network lookup, works offline, and is the most reliable option.
 
 ```dart
 import 'package:in_app_update_flutter/in_app_update_flutter.dart';
 
-await InAppUpdateFlutter().showUpdateForIos(appStoreId: '1234567890');
+await InAppUpdateFlutter().showStoreUpdateIosByAppStoreId(appStoreId: '1234567890');
 ```
 
 **How to find your App Store ID:**
 
 1. Open your app's App Store URL — for example: `https://apps.apple.com/app/id1234567890`
 2. The numeric portion after `id` is your App Store ID.
+
+### Option 2: Using the Bundle ID
+
+Pass your app's bundle ID instead. The plugin resolves the numeric App Store ID automatically via the iTunes Lookup API, then presents the update prompt.
+
+**Trade-off:** This option requires a network request before the prompt can appear. If the device is offline, the bundle ID is not found on the App Store, or the API returns an unexpected response, the call will throw a `PlatformException`. Use Option 1 if you already know your App Store ID.
+
+```dart
+await InAppUpdateFlutter().showStoreUpdateIosByBundleId(bundleId: 'com.example.myapp');
+```
+
+Since this involves a network call, it can fail. Always wrap it in a `try/catch`:
+
+```dart
+try {
+  await InAppUpdateFlutter().showStoreUpdateIosByBundleId(bundleId: 'com.example.myapp');
+} on PlatformException catch (e) {
+  switch (e.code) {
+    case 'NETWORK_ERROR':
+      // iTunes Lookup API was unreachable
+    case 'BUNDLE_ID_NOT_FOUND':
+      // No app found for this bundle ID on the App Store
+    case 'INVALID_RESPONSE':
+      // Unexpected response from the iTunes Lookup API
+    case 'STORE_ERROR':
+      // SKStoreProductViewController failed to load
+  }
+}
+```
 
 **iOS notes:**
 - Requires iOS 12.0 or later

--- a/android/src/main/kotlin/tech/axions/in_app_update_flutter/InAppUpdateFlutterPlugin.kt
+++ b/android/src/main/kotlin/tech/axions/in_app_update_flutter/InAppUpdateFlutterPlugin.kt
@@ -79,6 +79,9 @@ class InAppUpdateFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware
     }
 
     private fun unregisterActivityListener() {
+        installStateListener?.let { appUpdateManager?.unregisterListener(it) }
+        installStateListener = null
+        eventSink = null
         activityPluginBinding?.removeActivityResultListener(this)
         activityPluginBinding = null
         activity = null

--- a/example/integration_test/plugin_integration_test.dart
+++ b/example/integration_test/plugin_integration_test.dart
@@ -16,10 +16,10 @@ import 'package:in_app_update_flutter/in_app_update_flutter.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('showUpdateForIos test', (WidgetTester tester) async {
+  testWidgets('showStoreUpdateIosByAppStoreId test', (WidgetTester tester) async {
     final InAppUpdateFlutter plugin = InAppUpdateFlutter();
     if (Platform.isIOS) {
-      await plugin.showUpdateForIos(appStoreId: '544007664');
+      await plugin.showStoreUpdateIosByAppStoreId(appStoreId: '544007664');
     } else if (Platform.isAndroid) {
       final info = await plugin.checkUpdateAndroid();
       expect(info, isA<AppUpdateInfoAndroid>());

--- a/example/integration_test/plugin_integration_test.dart
+++ b/example/integration_test/plugin_integration_test.dart
@@ -16,7 +16,8 @@ import 'package:in_app_update_flutter/in_app_update_flutter.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('showStoreUpdateIosByAppStoreId test', (WidgetTester tester) async {
+  testWidgets('showStoreUpdateIosByAppStoreId test',
+      (WidgetTester tester) async {
     final InAppUpdateFlutter plugin = InAppUpdateFlutter();
     if (Platform.isIOS) {
       await plugin.showStoreUpdateIosByAppStoreId(appStoreId: '544007664');

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -38,7 +38,7 @@ class IosUpdateExample extends StatelessWidget {
           onPressed: () async {
             try {
               await InAppUpdateFlutter()
-                  .showUpdateForIos(appStoreId: '544007664');
+                  .showStoreUpdateIosByAppStoreId(appStoreId: '544007664');
             } catch (e) {
               if (context.mounted) {
                 ScaffoldMessenger.of(context).showSnackBar(

--- a/ios/in_app_update_flutter.podspec
+++ b/ios/in_app_update_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'in_app_update_flutter'
-  s.version          = '2.0.0'
+  s.version          = '2.1.0'
   s.summary          = 'Show an in-app update prompt using the native App Store product page.'
   s.description      = <<-DESC
 A Flutter plugin to show an in-app update prompt using the native App Store product page on iOS, keeping users inside your app.

--- a/ios/in_app_update_flutter/Sources/in_app_update_flutter/InAppUpdateFlutterPlugin.swift
+++ b/ios/in_app_update_flutter/Sources/in_app_update_flutter/InAppUpdateFlutterPlugin.swift
@@ -14,14 +14,75 @@ public class InAppUpdateFlutterPlugin: NSObject, FlutterPlugin, SKStoreProductVi
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-    if call.method == "showStoreUpdateIos",
-       let args = call.arguments as? [String: Any],
-       let appStoreId = args["appStoreId"] as? String {
+    switch call.method {
+    case "showStoreUpdateIosByAppStoreId", "showStoreUpdateIos":
+      guard let args = call.arguments as? [String: Any],
+            let appStoreId = args["appStoreId"] as? String else {
+        result(FlutterError(code: "INVALID_ARGUMENTS", message: "appStoreId is required", details: nil))
+        return
+      }
       flutterResult = result
       showStoreProductView(appStoreId: appStoreId)
-    } else {
+
+    case "showStoreUpdateIosByBundleId":
+      guard let args = call.arguments as? [String: Any],
+            let bundleId = args["bundleId"] as? String else {
+        result(FlutterError(code: "INVALID_ARGUMENTS", message: "bundleId is required", details: nil))
+        return
+      }
+      flutterResult = result
+      resolveAppStoreId(bundleId: bundleId)
+
+    default:
       result(FlutterMethodNotImplemented)
     }
+  }
+
+  private func resolveAppStoreId(bundleId: String) {
+    guard let url = URL(string: "https://itunes.apple.com/lookup?bundleId=\(bundleId)") else {
+      flutterResult?(FlutterError(code: "INVALID_ARGUMENTS", message: "Invalid bundle ID", details: nil))
+      return
+    }
+
+    let task = URLSession.shared.dataTask(with: url) { [weak self] data, _, error in
+      DispatchQueue.main.async {
+        guard let self = self else { return }
+
+        if let error = error {
+          self.flutterResult?(FlutterError(
+            code: "NETWORK_ERROR",
+            message: "Failed to reach iTunes lookup API",
+            details: error.localizedDescription
+          ))
+          return
+        }
+
+        guard let data = data,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let results = json["results"] as? [[String: Any]],
+              !results.isEmpty,
+              let trackId = results[0]["trackId"] as? Int else {
+          let resultCount = (try? JSONSerialization.jsonObject(with: data ?? Data()) as? [String: Any])?["resultCount"] as? Int ?? 0
+          if resultCount == 0 {
+            self.flutterResult?(FlutterError(
+              code: "BUNDLE_ID_NOT_FOUND",
+              message: "No app found for bundle ID: \(bundleId)",
+              details: nil
+            ))
+          } else {
+            self.flutterResult?(FlutterError(
+              code: "INVALID_RESPONSE",
+              message: "Unexpected response from iTunes lookup API",
+              details: nil
+            ))
+          }
+          return
+        }
+
+        self.showStoreProductView(appStoreId: String(trackId))
+      }
+    }
+    task.resume()
   }
 
   private func showStoreProductView(appStoreId: String) {

--- a/ios/in_app_update_flutter/Sources/in_app_update_flutter/InAppUpdateFlutterPlugin.swift
+++ b/ios/in_app_update_flutter/Sources/in_app_update_flutter/InAppUpdateFlutterPlugin.swift
@@ -3,13 +3,10 @@ import Flutter
 import StoreKit
 
 public class InAppUpdateFlutterPlugin: NSObject, FlutterPlugin, SKStoreProductViewControllerDelegate {
-  var flutterResult: FlutterResult?
-  var controller: UIViewController?
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(name: "in_app_update_flutter", binaryMessenger: registrar.messenger())
     let instance = InAppUpdateFlutterPlugin()
-    instance.controller = UIApplication.shared.delegate?.window??.rootViewController
     registrar.addMethodCallDelegate(instance, channel: channel)
   }
 
@@ -21,8 +18,7 @@ public class InAppUpdateFlutterPlugin: NSObject, FlutterPlugin, SKStoreProductVi
         result(FlutterError(code: "INVALID_ARGUMENTS", message: "appStoreId is required", details: nil))
         return
       }
-      flutterResult = result
-      showStoreProductView(appStoreId: appStoreId)
+      showStoreProductView(appStoreId: appStoreId, result: result)
 
     case "showStoreUpdateIosByBundleId":
       guard let args = call.arguments as? [String: Any],
@@ -30,17 +26,16 @@ public class InAppUpdateFlutterPlugin: NSObject, FlutterPlugin, SKStoreProductVi
         result(FlutterError(code: "INVALID_ARGUMENTS", message: "bundleId is required", details: nil))
         return
       }
-      flutterResult = result
-      resolveAppStoreId(bundleId: bundleId)
+      resolveAppStoreId(bundleId: bundleId, result: result)
 
     default:
       result(FlutterMethodNotImplemented)
     }
   }
 
-  private func resolveAppStoreId(bundleId: String) {
+  private func resolveAppStoreId(bundleId: String, result: @escaping FlutterResult) {
     guard let url = URL(string: "https://itunes.apple.com/lookup?bundleId=\(bundleId)") else {
-      flutterResult?(FlutterError(code: "INVALID_ARGUMENTS", message: "Invalid bundle ID", details: nil))
+      result(FlutterError(code: "INVALID_ARGUMENTS", message: "Invalid bundle ID", details: nil))
       return
     }
 
@@ -49,7 +44,7 @@ public class InAppUpdateFlutterPlugin: NSObject, FlutterPlugin, SKStoreProductVi
         guard let self = self else { return }
 
         if let error = error {
-          self.flutterResult?(FlutterError(
+          result(FlutterError(
             code: "NETWORK_ERROR",
             message: "Failed to reach iTunes lookup API",
             details: error.localizedDescription
@@ -64,13 +59,13 @@ public class InAppUpdateFlutterPlugin: NSObject, FlutterPlugin, SKStoreProductVi
               let trackId = results[0]["trackId"] as? Int else {
           let resultCount = (try? JSONSerialization.jsonObject(with: data ?? Data()) as? [String: Any])?["resultCount"] as? Int ?? 0
           if resultCount == 0 {
-            self.flutterResult?(FlutterError(
+            result(FlutterError(
               code: "BUNDLE_ID_NOT_FOUND",
               message: "No app found for bundle ID: \(bundleId)",
               details: nil
             ))
           } else {
-            self.flutterResult?(FlutterError(
+            result(FlutterError(
               code: "INVALID_RESPONSE",
               message: "Unexpected response from iTunes lookup API",
               details: nil
@@ -79,32 +74,53 @@ public class InAppUpdateFlutterPlugin: NSObject, FlutterPlugin, SKStoreProductVi
           return
         }
 
-        self.showStoreProductView(appStoreId: String(trackId))
+        self.showStoreProductView(appStoreId: String(trackId), result: result)
       }
     }
     task.resume()
   }
 
-  private func showStoreProductView(appStoreId: String) {
+  private func showStoreProductView(appStoreId: String, result: @escaping FlutterResult) {
+    guard let vc = topViewController() else {
+      result(FlutterError(code: "STORE_NOT_LOADED", message: "Could not find a view controller to present from", details: nil))
+      return
+    }
+
     let productViewController = SKStoreProductViewController()
     productViewController.delegate = self
 
-    let parameters = [SKStoreProductParameterITunesItemIdentifier : appStoreId]
+    let parameters = [SKStoreProductParameterITunesItemIdentifier: appStoreId]
 
-    productViewController.loadProduct(withParameters: parameters) { loaded, error in
-      if let error = error {
-        self.flutterResult?(FlutterError(code: "STORE_ERROR", message: "Failed to load product", details: error.localizedDescription))
-        return
-      }
+    productViewController.loadProduct(withParameters: parameters) { [weak self] loaded, error in
+      DispatchQueue.main.async {
+        guard self != nil else { return }
 
-      if loaded, let vc = self.controller {
-        vc.present(productViewController, animated: true) {
-          self.flutterResult?(nil)
+        if let error = error {
+          result(FlutterError(code: "STORE_ERROR", message: "Failed to load product", details: error.localizedDescription))
+          return
         }
-      } else {
-        self.flutterResult?(FlutterError(code: "STORE_NOT_LOADED", message: "Could not load product", details: nil))
+
+        if loaded {
+          vc.present(productViewController, animated: true) {
+            result(nil)
+          }
+        } else {
+          result(FlutterError(code: "STORE_NOT_LOADED", message: "Could not load product", details: nil))
+        }
       }
     }
+  }
+
+  /// Walks the view controller hierarchy to find the topmost presented controller,
+  /// which is the correct one to present from at call time.
+  private func topViewController() -> UIViewController? {
+    guard var top = UIApplication.shared.delegate?.window??.rootViewController else {
+      return nil
+    }
+    while let presented = top.presentedViewController {
+      top = presented
+    }
+    return top
   }
 
   public func productViewControllerDidFinish(_ viewController: SKStoreProductViewController) {

--- a/lib/in_app_update_flutter.dart
+++ b/lib/in_app_update_flutter.dart
@@ -17,7 +17,7 @@ class InAppUpdateFlutter {
   /// [appStoreId] is the numeric App Store ID of your app
   /// (found in your App Store Connect URL).
   @Deprecated(
-    'Use showUpdateForIos() on iOS or checkUpdateAndroid() + '
+    'Use showStoreUpdateIosByAppStoreId() on iOS or checkUpdateAndroid() + '
     'startImmediateUpdateAndroid()/startFlexibleUpdateAndroid() on Android',
   )
   Future<void> showUpdate({required String appStoreId}) {
@@ -30,9 +30,31 @@ class InAppUpdateFlutter {
   ///
   /// [appStoreId] is the numeric App Store ID of your app
   /// (found in your App Store Connect URL).
+  @Deprecated('Use showStoreUpdateIosByAppStoreId() instead.')
   Future<void> showUpdateForIos({required String appStoreId}) {
     return InAppUpdateFlutterPlatform.instance
-        .showUpdateForIos(appStoreId: appStoreId);
+        .showStoreUpdateIosByAppStoreId(appStoreId: appStoreId);
+  }
+
+  /// iOS: Shows the App Store product page overlay via StoreKit.
+  ///
+  /// [appStoreId] is the numeric App Store ID of your app
+  /// (found in your App Store Connect URL).
+  Future<void> showStoreUpdateIosByAppStoreId({required String appStoreId}) {
+    return InAppUpdateFlutterPlatform.instance
+        .showStoreUpdateIosByAppStoreId(appStoreId: appStoreId);
+  }
+
+  /// iOS: Resolves the App Store ID from [bundleId] via the iTunes Lookup API,
+  /// then shows the App Store product page overlay via StoreKit.
+  ///
+  /// Throws a [PlatformException] if:
+  /// - The network request fails (`NETWORK_ERROR`)
+  /// - The bundle ID is not found on the App Store (`BUNDLE_ID_NOT_FOUND`)
+  /// - The API returns an unexpected response (`INVALID_RESPONSE`)
+  Future<void> showStoreUpdateIosByBundleId({required String bundleId}) {
+    return InAppUpdateFlutterPlatform.instance
+        .showStoreUpdateIosByBundleId(bundleId: bundleId);
   }
 
   /// Android: Checks whether an in-app update is available via Play Core.

--- a/lib/in_app_update_flutter.dart
+++ b/lib/in_app_update_flutter.dart
@@ -5,8 +5,9 @@ export 'package:in_app_update_flutter/src/models/models.dart';
 
 /// A Flutter plugin for in-app updates.
 ///
-/// On iOS, use [showUpdateForIos] to present the App Store product page
-/// using StoreKit.
+/// On iOS, use [showStoreUpdateIosByAppStoreId] to present the App Store
+/// product page using StoreKit, or [showStoreUpdateIosByBundleId] to resolve
+/// the App Store ID automatically from a bundle ID.
 ///
 /// On Android, use [checkUpdateAndroid] to check for updates via Google Play's
 /// In-App Updates API, then [startImmediateUpdateAndroid] or

--- a/lib/src/method_channel/in_app_update_flutter_method_channel.dart
+++ b/lib/src/method_channel/in_app_update_flutter_method_channel.dart
@@ -16,8 +16,8 @@ class MethodChannelInAppUpdateFlutter extends InAppUpdateFlutterPlatform {
 
   @override
   @Deprecated(
-    'Use showUpdateForIos() on iOS or checkUpdateAndroid() + '
-    'startImmediateUpdateAndroid()/startFlexibleUpdateAndroid() on Android',
+    'Use showStoreUpdateIosByAppStoreId() or showStoreUpdateIosByBundleId() on iOS, '
+    'or checkUpdateAndroid() + startImmediateUpdateAndroid()/startFlexibleUpdateAndroid() on Android',
   )
   Future<void> showUpdate({required String appStoreId}) async {
     await _methodChannel.invokeMethod('showStoreUpdateIos', {
@@ -26,9 +26,26 @@ class MethodChannelInAppUpdateFlutter extends InAppUpdateFlutterPlatform {
   }
 
   @override
+  @Deprecated('Use showStoreUpdateIosByAppStoreId() instead.')
   Future<void> showUpdateForIos({required String appStoreId}) async {
-    await _methodChannel.invokeMethod('showStoreUpdateIos', {
+    await _methodChannel.invokeMethod('showStoreUpdateIosByAppStoreId', {
       'appStoreId': appStoreId,
+    });
+  }
+
+  @override
+  Future<void> showStoreUpdateIosByAppStoreId({
+    required String appStoreId,
+  }) async {
+    await _methodChannel.invokeMethod('showStoreUpdateIosByAppStoreId', {
+      'appStoreId': appStoreId,
+    });
+  }
+
+  @override
+  Future<void> showStoreUpdateIosByBundleId({required String bundleId}) async {
+    await _methodChannel.invokeMethod('showStoreUpdateIosByBundleId', {
+      'bundleId': bundleId,
     });
   }
 

--- a/lib/src/platform_interface/in_app_update_flutter_platform_interface.dart
+++ b/lib/src/platform_interface/in_app_update_flutter_platform_interface.dart
@@ -34,8 +34,8 @@ abstract class InAppUpdateFlutterPlatform extends PlatformInterface {
   /// On iOS, this presents the App Store product page using StoreKit.
   /// [appStoreId] is the numeric App Store ID of your app.
   @Deprecated(
-    'Use showUpdateForIos() on iOS or checkUpdateAndroid() + '
-    'startImmediateUpdateAndroid()/startFlexibleUpdateAndroid() on Android',
+    'Use showStoreUpdateIosByAppStoreId() or showStoreUpdateIosByBundleId() on iOS, '
+    'or checkUpdateAndroid() + startImmediateUpdateAndroid()/startFlexibleUpdateAndroid() on Android',
   )
   Future<void> showUpdate({required String appStoreId}) {
     throw UnimplementedError('showUpdate() has not been implemented.');
@@ -45,8 +45,32 @@ abstract class InAppUpdateFlutterPlatform extends PlatformInterface {
   ///
   /// [appStoreId] is the numeric App Store ID of your app
   /// (found in your App Store Connect URL).
+  @Deprecated('Use showStoreUpdateIosByAppStoreId() instead.')
   Future<void> showUpdateForIos({required String appStoreId}) {
     throw UnimplementedError('showUpdateForIos() has not been implemented.');
+  }
+
+  /// iOS: Shows the App Store product page overlay via StoreKit.
+  ///
+  /// [appStoreId] is the numeric App Store ID of your app
+  /// (found in your App Store Connect URL).
+  Future<void> showStoreUpdateIosByAppStoreId({required String appStoreId}) {
+    throw UnimplementedError(
+      'showStoreUpdateIosByAppStoreId() has not been implemented.',
+    );
+  }
+
+  /// iOS: Resolves the App Store ID from [bundleId] via the iTunes Lookup API,
+  /// then shows the App Store product page overlay via StoreKit.
+  ///
+  /// Throws a [PlatformException] if:
+  /// - The network request fails (`NETWORK_ERROR`)
+  /// - The bundle ID is not found on the App Store (`BUNDLE_ID_NOT_FOUND`)
+  /// - The API returns an unexpected response (`INVALID_RESPONSE`)
+  Future<void> showStoreUpdateIosByBundleId({required String bundleId}) {
+    throw UnimplementedError(
+      'showStoreUpdateIosByBundleId() has not been implemented.',
+    );
   }
 
   /// Android: Checks whether an in-app update is available via Play Core.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: in_app_update_flutter
 description: "A Flutter plugin to show an in-app update prompt using the native App Store product page on iOS, keeping users inside your app."
-version: 2.0.0
-repository: https://github.com/pulkit7724/in_app_update_flutter.git
+version: 2.1.0
+repository: https://github.com/axions-org/in_app_update_flutter
 
 environment:
   sdk: ^3.6.2

--- a/test/in_app_update_flutter_method_channel_test.dart
+++ b/test/in_app_update_flutter_method_channel_test.dart
@@ -20,8 +20,8 @@ void main() {
   });
 
   group('MethodChannelInAppUpdateFlutter', () {
-    group('showUpdateForIos', () {
-      test('calls showStoreUpdateIos method on the channel', () async {
+    group('showStoreUpdateIosByAppStoreId', () {
+      test('calls showStoreUpdateIosByAppStoreId method on the channel', () async {
         String? invokedMethod;
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(methodChannel, (call) async {
@@ -29,8 +29,8 @@ void main() {
           return null;
         });
 
-        await plugin.showUpdateForIos(appStoreId: '544007664');
-        expect(invokedMethod, 'showStoreUpdateIos');
+        await plugin.showStoreUpdateIosByAppStoreId(appStoreId: '544007664');
+        expect(invokedMethod, 'showStoreUpdateIosByAppStoreId');
       });
 
       test('passes appStoreId argument to the channel', () async {
@@ -41,7 +41,7 @@ void main() {
           return null;
         });
 
-        await plugin.showUpdateForIos(appStoreId: '544007664');
+        await plugin.showStoreUpdateIosByAppStoreId(appStoreId: '544007664');
         expect(invokedArgs, {'appStoreId': '544007664'});
       });
 
@@ -55,7 +55,63 @@ void main() {
         });
 
         expect(
-          () => plugin.showUpdateForIos(appStoreId: '544007664'),
+          () => plugin.showStoreUpdateIosByAppStoreId(appStoreId: '544007664'),
+          throwsA(isA<PlatformException>()),
+        );
+      });
+    });
+
+    group('showStoreUpdateIosByBundleId', () {
+      test('calls showStoreUpdateIosByBundleId method on the channel', () async {
+        String? invokedMethod;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(methodChannel, (call) async {
+          invokedMethod = call.method;
+          return null;
+        });
+
+        await plugin.showStoreUpdateIosByBundleId(bundleId: 'com.example.app');
+        expect(invokedMethod, 'showStoreUpdateIosByBundleId');
+      });
+
+      test('passes bundleId argument to the channel', () async {
+        Map<dynamic, dynamic>? invokedArgs;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(methodChannel, (call) async {
+          invokedArgs = call.arguments as Map<dynamic, dynamic>;
+          return null;
+        });
+
+        await plugin.showStoreUpdateIosByBundleId(bundleId: 'com.example.app');
+        expect(invokedArgs, {'bundleId': 'com.example.app'});
+      });
+
+      test('propagates NETWORK_ERROR', () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(methodChannel, (call) async {
+          throw PlatformException(
+            code: 'NETWORK_ERROR',
+            message: 'Failed to reach iTunes lookup API',
+          );
+        });
+
+        expect(
+          () => plugin.showStoreUpdateIosByBundleId(bundleId: 'com.example.app'),
+          throwsA(isA<PlatformException>()),
+        );
+      });
+
+      test('propagates BUNDLE_ID_NOT_FOUND', () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(methodChannel, (call) async {
+          throw PlatformException(
+            code: 'BUNDLE_ID_NOT_FOUND',
+            message: 'No app found for bundle ID: com.example.app',
+          );
+        });
+
+        expect(
+          () => plugin.showStoreUpdateIosByBundleId(bundleId: 'com.example.app'),
           throwsA(isA<PlatformException>()),
         );
       });

--- a/test/in_app_update_flutter_method_channel_test.dart
+++ b/test/in_app_update_flutter_method_channel_test.dart
@@ -21,7 +21,8 @@ void main() {
 
   group('MethodChannelInAppUpdateFlutter', () {
     group('showStoreUpdateIosByAppStoreId', () {
-      test('calls showStoreUpdateIosByAppStoreId method on the channel', () async {
+      test('calls showStoreUpdateIosByAppStoreId method on the channel',
+          () async {
         String? invokedMethod;
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(methodChannel, (call) async {
@@ -62,7 +63,8 @@ void main() {
     });
 
     group('showStoreUpdateIosByBundleId', () {
-      test('calls showStoreUpdateIosByBundleId method on the channel', () async {
+      test('calls showStoreUpdateIosByBundleId method on the channel',
+          () async {
         String? invokedMethod;
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(methodChannel, (call) async {
@@ -96,7 +98,8 @@ void main() {
         });
 
         expect(
-          () => plugin.showStoreUpdateIosByBundleId(bundleId: 'com.example.app'),
+          () =>
+              plugin.showStoreUpdateIosByBundleId(bundleId: 'com.example.app'),
           throwsA(isA<PlatformException>()),
         );
       });
@@ -111,7 +114,8 @@ void main() {
         });
 
         expect(
-          () => plugin.showStoreUpdateIosByBundleId(bundleId: 'com.example.app'),
+          () =>
+              plugin.showStoreUpdateIosByBundleId(bundleId: 'com.example.app'),
           throwsA(isA<PlatformException>()),
         );
       });

--- a/test/in_app_update_flutter_test.dart
+++ b/test/in_app_update_flutter_test.dart
@@ -7,16 +7,30 @@ import 'package:flutter_test/flutter_test.dart';
 /// the correct token so it can be set as the platform instance.
 class _MockPlatform extends InAppUpdateFlutterPlatform {
   String? lastAppStoreId;
-
-  @override
-  Future<void> showUpdateForIos({required String appStoreId}) async {
-    lastAppStoreId = appStoreId;
-  }
+  String? lastBundleId;
 
   @override
   // ignore: deprecated_member_use_from_same_package
   Future<void> showUpdate({required String appStoreId}) async {
     lastAppStoreId = appStoreId;
+  }
+
+  @override
+  // ignore: deprecated_member_use_from_same_package
+  Future<void> showUpdateForIos({required String appStoreId}) async {
+    lastAppStoreId = appStoreId;
+  }
+
+  @override
+  Future<void> showStoreUpdateIosByAppStoreId({
+    required String appStoreId,
+  }) async {
+    lastAppStoreId = appStoreId;
+  }
+
+  @override
+  Future<void> showStoreUpdateIosByBundleId({required String bundleId}) async {
+    lastBundleId = bundleId;
   }
 
   @override
@@ -104,7 +118,24 @@ void main() {
 
       test('showUpdateForIos throws UnimplementedError', () {
         expect(
+          // ignore: deprecated_member_use_from_same_package
           () => platform.showUpdateForIos(appStoreId: '123'),
+          throwsA(isA<UnimplementedError>()),
+        );
+      });
+
+      test('showStoreUpdateIosByAppStoreId throws UnimplementedError', () {
+        expect(
+          () => platform.showStoreUpdateIosByAppStoreId(appStoreId: '123'),
+          throwsA(isA<UnimplementedError>()),
+        );
+      });
+
+      test('showStoreUpdateIosByBundleId throws UnimplementedError', () {
+        expect(
+          () => platform.showStoreUpdateIosByBundleId(
+            bundleId: 'com.example.app',
+          ),
           throwsA(isA<UnimplementedError>()),
         );
       });
@@ -146,13 +177,23 @@ void main() {
     });
 
     group('mock platform delegates', () {
-      test('showUpdateForIos passes appStoreId to mock', () async {
+      test('showStoreUpdateIosByAppStoreId passes appStoreId to mock',
+          () async {
         final mock = _MockPlatform();
         InAppUpdateFlutterPlatform.instance = mock;
 
         await InAppUpdateFlutterPlatform.instance
-            .showUpdateForIos(appStoreId: '544007664');
+            .showStoreUpdateIosByAppStoreId(appStoreId: '544007664');
         expect(mock.lastAppStoreId, '544007664');
+      });
+
+      test('showStoreUpdateIosByBundleId passes bundleId to mock', () async {
+        final mock = _MockPlatform();
+        InAppUpdateFlutterPlatform.instance = mock;
+
+        await InAppUpdateFlutterPlatform.instance
+            .showStoreUpdateIosByBundleId(bundleId: 'com.example.app');
+        expect(mock.lastBundleId, 'com.example.app');
       });
 
       test('checkUpdateAndroid returns expected info', () async {


### PR DESCRIPTION
## Summary

- Adds `showStoreUpdateIosByBundleId(bundleId: ...)` — resolves the numeric App Store ID internally via the iTunes Lookup API (`itunes.apple.com/lookup?bundleId=...`), then presents `SKStoreProductViewController`
- Renames `showUpdateForIos()` to `showStoreUpdateIosByAppStoreId()` — old method kept and marked `@Deprecated` for backward compatibility
- All 4 layers updated: Swift, platform interface, method channel, public API

## Error handling

| Code | Cause |
|---|---|
| `NETWORK_ERROR` | iTunes Lookup API unreachable |
| `BUNDLE_ID_NOT_FOUND` | No app found for the given bundle ID |
| `INVALID_RESPONSE` | Unexpected API response format |
| `INVALID_ARGUMENTS` | Missing or invalid method arguments |

## Test plan

- [x] `showStoreUpdateIosByAppStoreId` presents App Store overlay on a real device
- [x] `showStoreUpdateIosByBundleId` resolves correctly and presents overlay
- [x] `showStoreUpdateIosByBundleId` with an invalid bundle ID returns `BUNDLE_ID_NOT_FOUND`
- [x] `showStoreUpdateIosByBundleId` with no network returns `NETWORK_ERROR`
- [x] Deprecated `showUpdateForIos` still works without breaking

🤖 Generated with [Claude Code](https://claude.com/claude-code)