### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,112 @@
+name: Bug Report
+description: Report a bug or unexpected behavior in in_app_update_flutter
+labels: ["bug", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill in as much detail as possible so we can reproduce and fix the issue.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I have searched existing issues and this is not a duplicate
+          required: true
+        - label: I have updated to the latest version of the package and the bug still occurs
+          required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      description: Which platform(s) does this affect?
+      multiple: true
+      options:
+        - Android
+        - iOS
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug description
+      description: A clear and concise description of what the bug is.
+      placeholder: "When I call showStoreUpdateIosByBundleId, the app crashes with..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Step-by-step instructions to reproduce the behavior.
+      placeholder: |
+        1. Call `InAppUpdateFlutter().showStoreUpdateIosByBundleId(bundleId: 'com.example.app')`
+        2. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: code
+    attributes:
+      label: Minimal reproducible code
+      description: Paste the smallest snippet that demonstrates the issue.
+      render: dart
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / stack trace
+      description: Paste any relevant logs or crash output here.
+      render: shell
+
+  - type: input
+    id: package_version
+    attributes:
+      label: Package version
+      placeholder: "e.g. 2.1.0"
+    validations:
+      required: true
+
+  - type: input
+    id: flutter_version
+    attributes:
+      label: Flutter version
+      description: Output of `flutter --version`
+      placeholder: "e.g. Flutter 3.27.0, Dart 3.6.0"
+    validations:
+      required: true
+
+  - type: input
+    id: os_version
+    attributes:
+      label: OS / device
+      description: OS name, version, and device/emulator type
+      placeholder: "e.g. iOS 17.4 (iPhone 15 simulator), Android 14 (Pixel 8)"
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other context, screenshots, or information that might help.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a question
+    url: https://github.com/axions-org/in_app_update_flutter/discussions
+    about: Please ask questions here instead of opening issues

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,65 @@
+name: Feature Request
+description: Suggest a new feature or improvement for in_app_update_flutter
+labels: ["enhancement", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea to make this plugin better? Describe it below. For general questions, please use [Discussions](https://github.com/axions-org/in_app_update_flutter/discussions) instead.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I have searched existing issues and this is not a duplicate
+          required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      description: Which platform(s) does this feature apply to?
+      multiple: true
+      options:
+        - Android
+        - iOS
+        - Both / Cross-platform
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve, or what limitation does it address?
+      placeholder: "Currently there is no way to... which means I have to..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the feature you'd like and how it should work.
+    validations:
+      required: true
+
+  - type: textarea
+    id: api
+    attributes:
+      label: Suggested API (optional)
+      description: If you have a specific API design in mind, sketch it out here.
+      render: dart
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative solutions or workarounds you've already explored.
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Links, references, screenshots, or anything else that supports the request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+## Description
+
+<!-- What does this PR do and why? Link any related issues with "Fixes #<number>" -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / code quality
+- [ ] Docs / comments
+- [ ] CI/CD / tooling
+- [ ] Release / version bump
+
+## Platform(s) affected
+
+- [ ] Android (Kotlin / Play Core)
+- [ ] iOS (Swift / StoreKit)
+- [ ] Dart / Flutter API
+- [ ] Not platform-specific
+
+## Checklist
+
+- [ ] Tested on a real device or emulator (not just unit tests)
+- [ ] Dart API changes are reflected in both platforms (if applicable)
+- [ ] Public API changes are documented in the README
+- [ ] `CHANGELOG.md` updated (for user-facing changes)
+- [ ] Existing tests pass (`flutter test`)
+- [ ] New tests added for new behavior (if applicable)
+
+## Testing notes
+
+<!-- Describe how you tested this. Include device/OS versions, update scenarios (immediate, flexible, App Store), and any edge cases checked. -->


### PR DESCRIPTION
## Summary

- Adds structured `bug_report.yml` template with platform selector, reproduction steps, version fields, and log capture
- Adds structured `feature_request.yml` template with motivation, proposed solution, and optional API sketch fields
- Adds `config.yml` to disable blank issues and redirect questions to Discussions

## Test plan

- [ ] Verify templates appear correctly on the GitHub "New Issue" page
- [ ] Confirm blank issue creation is disabled
- [ ] Check that the Discussions link appears as a contact option

🤖 Generated with [Claude Code](https://claude.com/claude-code)