### PR TITLE
chore: fix pub.dev metadata and remove stale bundle ID references

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -34,7 +34,7 @@ body:
     attributes:
       label: Bug description
       description: A clear and concise description of what the bug is.
-      placeholder: "When I call showStoreUpdateIosByBundleId, the app crashes with..."
+      placeholder: "When I call showUpdateForIos, the app crashes with..."
     validations:
       required: true
 
@@ -44,7 +44,7 @@ body:
       label: Steps to reproduce
       description: Step-by-step instructions to reproduce the behavior.
       placeholder: |
-        1. Call `InAppUpdateFlutter().showStoreUpdateIosByBundleId(bundleId: 'com.example.app')`
+        1. Call `InAppUpdateFlutter().showUpdateForIos(appStoreId: '544007664')`
         2. ...
     validations:
       required: true

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -99,7 +99,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.3"
+    version: "2.0.0"
   integration_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,13 @@
 name: in_app_update_flutter
 description: "A Flutter plugin to show an in-app update prompt using the native App Store product page on iOS, keeping users inside your app."
 version: 2.0.0
-repository: https://github.com/pulkit7724/in_app_update_flutter.git
+repository: https://github.com/axions-org/in_app_update_flutter
+issue_tracker: https://github.com/axions-org/in_app_update_flutter/issues
+topics:
+  - in-app-update
+  - app-update
+  - flutter-plugin
+  - app-store
 
 environment:
   sdk: ^3.6.2


### PR DESCRIPTION
## Summary
- Fix repository URL in pubspec.yaml (`pulkit7724` → `axions-org`, remove `.git` suffix) to pass pub.dev validation
- Add `issue_tracker` and `topics` to pubspec.yaml
- Update bug report template to reference current `showUpdateForIos` API instead of removed `showStoreUpdateIosByBundleId`

## Test plan
- [x] Verify pub.dev score improves with correct repository URL
- [x] Confirm issue template renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)