### PR TITLE
feat: iOS update check via iTunes Lookup API (checkUpdateIos)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - **Fixed iOS `showUpdateForIos` always failing with `STORE_NOT_LOADED`.** The App Store ID is now passed to StoreKit as an `NSNumber` (as required by `SKStoreProductParameterITunesItemIdentifier`) instead of a `String`, so the App Store overlay loads correctly.
 - Fixed the App Store overlay failing to present because the view controller was captured (and often `nil`) at plugin registration. It is now resolved at call time via the active window scene.
 - Added distinct error codes for clearer diagnostics: `INVALID_APP_STORE_ID` (non-numeric ID) and `NO_VIEW_CONTROLLER` (nothing available to present from), separate from `STORE_NOT_LOADED`.
+- Added an optional `region` parameter to `checkUpdateIos()` (ISO 3166-1 alpha-2, e.g. `'gb'`) to target a specific App Store region when the device region differs from the storefront the app is published in. Defaults to the device region (`Locale.current`).
 - **BREAKING:** Raised the minimum supported iOS version from 12.0 to 13.0.
 
 ## 2.0.3

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Flutter plugin for in-app updates on both iOS and Android.
 
-On **iOS**, it presents the App Store product page using `SKStoreProductViewController` (StoreKit), keeping users inside the app during the update flow. On **Android**, it integrates with Google Play's In-App Updates API to support both immediate (blocking) and flexible (background) update flows.
+On **iOS**, it checks for updates via the iTunes Lookup API and presents the App Store product page using `SKStoreProductViewController` (StoreKit), keeping users inside the app during the update flow. On **Android**, it integrates with Google Play's In-App Updates API to support both immediate (blocking) and flexible (background) update flows.
 
 ---
 
@@ -16,6 +16,7 @@ On **iOS**, it presents the App Store product page using `SKStoreProductViewCont
 
 ## Features
 
+- iOS: Check for updates via the iTunes Lookup API natively (no extra Dart packages), auto-scoped to the device's region
 - iOS: Show the App Store update prompt using `SKStoreProductViewController` without navigating users away from the app
 - iOS: Native Swift implementation with zero AppDelegate configuration required
 - iOS: Supports both Swift Package Manager (SPM) and CocoaPods
@@ -45,6 +46,40 @@ flutter pub get
 ---
 
 ## iOS Usage
+
+### Check for an update
+
+Call `checkUpdateIos()` to query the iTunes Lookup API and compare the latest
+App Store version against the currently installed version. The check runs
+natively in the Swift plugin (via `URLSession`), so no extra Dart packages and
+no App Store ID are required — the app's bundle ID is used.
+
+The lookup is automatically scoped to the **device's region setting**
+(`Locale.current`), so apps that aren't published in the US store are looked up
+in the right region without any configuration.
+
+```dart
+import 'package:in_app_update_flutter/in_app_update_flutter.dart';
+
+final plugin = InAppUpdateFlutter();
+
+final info = await plugin.checkUpdateIos();
+
+if (info.updateAvailable) {
+  print('Update available: ${info.storeVersion} (installed ${info.installedVersion})');
+}
+```
+
+#### AppUpdateInfoIos fields
+
+| Field | Type | Description |
+|---|---|---|
+| `storeVersion` | `String` | Latest version published on the App Store |
+| `installedVersion` | `String` | Version currently installed |
+| `updateAvailable` | `bool` | `true` if `storeVersion` > `installedVersion` |
+| `bundleId` | `String` | Bundle ID used for the lookup |
+
+### Show the update prompt
 
 Pass your numeric App Store ID to `showUpdateForIos`. The ID can be found in your App Store Connect URL or the app's public App Store link.
 

--- a/example/ios/RunnerTests/RunnerTests.swift
+++ b/example/ios/RunnerTests/RunnerTests.swift
@@ -49,6 +49,25 @@ class RunnerTests: XCTestCase {
     waitForExpectations(timeout: 1)
   }
 
+  func testResolveRegionUsesOverride() {
+    // An explicit override wins and is normalized to lowercase.
+    XCTAssertEqual(InAppUpdateFlutterPlugin.resolveRegion(override: "GB"), "gb")
+    XCTAssertEqual(InAppUpdateFlutterPlugin.resolveRegion(override: "  us  "), "us")
+  }
+
+  func testResolveRegionFallsBackToLocaleWhenOverrideBlank() {
+    // A nil/blank override falls through to the device region (Locale.current),
+    // so the result must match the device's own alpha-2 region code.
+    let expected: String
+    if #available(iOS 16, *) {
+      expected = Locale.current.region?.identifier.lowercased() ?? ""
+    } else {
+      expected = Locale.current.regionCode?.lowercased() ?? ""
+    }
+    XCTAssertEqual(InAppUpdateFlutterPlugin.resolveRegion(override: nil), expected)
+    XCTAssertEqual(InAppUpdateFlutterPlugin.resolveRegion(override: "   "), expected)
+  }
+
   func testUnknownMethod() {
     let plugin = InAppUpdateFlutterPlugin()
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -99,7 +99,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.3"
   integration_test:
     dependency: "direct dev"
     description: flutter
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
@@ -250,10 +250,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   vector_math:
     dependency: transitive
     description:
@@ -279,5 +279,5 @@ packages:
     source: hosted
     version: "3.0.4"
 sdks:
-  dart: ">=3.9.0-0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/ios/in_app_update_flutter/Sources/in_app_update_flutter/InAppUpdateFlutterPlugin.swift
+++ b/ios/in_app_update_flutter/Sources/in_app_update_flutter/InAppUpdateFlutterPlugin.swift
@@ -57,7 +57,8 @@ public class InAppUpdateFlutterPlugin: NSObject, FlutterPlugin, SKStoreProductVi
     }
 
     guard !bundleId.isEmpty,
-          let url = URL(string: "https://itunes.apple.com\(regionPath)/lookup?bundleId=\(bundleId)") else {
+          let encodedBundleId = bundleId.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+          let url = URL(string: "https://itunes.apple.com\(regionPath)/lookup?bundleId=\(encodedBundleId)") else {
       reply("", false)
       return
     }
@@ -71,7 +72,10 @@ public class InAppUpdateFlutterPlugin: NSObject, FlutterPlugin, SKStoreProductVi
         reply("", false)
         return
       }
-      let updateAvailable = storeVersion.compare(installedVersion, options: .numeric) == .orderedDescending
+      // Only report an update when the installed version is known; an empty
+      // installed version is non-comparable and must not be treated as stale.
+      let updateAvailable = !installedVersion.isEmpty &&
+        storeVersion.compare(installedVersion, options: .numeric) == .orderedDescending
       reply(storeVersion, updateAvailable)
     }.resume()
   }

--- a/ios/in_app_update_flutter/Sources/in_app_update_flutter/InAppUpdateFlutterPlugin.swift
+++ b/ios/in_app_update_flutter/Sources/in_app_update_flutter/InAppUpdateFlutterPlugin.swift
@@ -14,14 +14,66 @@ public class InAppUpdateFlutterPlugin: NSObject, FlutterPlugin, SKStoreProductVi
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-    if call.method == "showStoreUpdateIos",
-       let args = call.arguments as? [String: Any],
-       let appStoreId = args["appStoreId"] as? String {
+    switch call.method {
+    case "showStoreUpdateIos":
+      guard let args = call.arguments as? [String: Any],
+            let appStoreId = args["appStoreId"] as? String else {
+        result(FlutterError(code: "BAD_ARGS", message: "appStoreId is required", details: nil))
+        return
+      }
       flutterResult = result
       showStoreProductView(appStoreId: appStoreId)
-    } else {
+    case "checkUpdateIos":
+      checkUpdate(result: result)
+    default:
       result(FlutterMethodNotImplemented)
     }
+  }
+
+  private func checkUpdate(result: @escaping FlutterResult) {
+    let bundleId = Bundle.main.bundleIdentifier ?? ""
+    let installedVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+
+    // Region comes from the device's language & region settings as an ISO
+    // 3166-1 alpha-2 code (e.g. "us", "gb") — the same form the iTunes Lookup
+    // API expects, so no conversion table is needed. Without a region the API
+    // defaults to the US store, which would miss apps not listed there.
+    let regionCode: String
+    if #available(iOS 16, *) {
+      regionCode = Locale.current.region?.identifier.lowercased() ?? ""
+    } else {
+      regionCode = Locale.current.regionCode?.lowercased() ?? ""
+    }
+    let regionPath = regionCode.isEmpty ? "" : "/\(regionCode)"
+
+    func reply(_ storeVersion: String, _ updateAvailable: Bool) {
+      let payload: [String: Any] = [
+        "storeVersion": storeVersion,
+        "installedVersion": installedVersion,
+        "updateAvailable": updateAvailable,
+        "bundleId": bundleId,
+      ]
+      DispatchQueue.main.async { result(payload) }
+    }
+
+    guard !bundleId.isEmpty,
+          let url = URL(string: "https://itunes.apple.com\(regionPath)/lookup?bundleId=\(bundleId)") else {
+      reply("", false)
+      return
+    }
+
+    let request = URLRequest(url: url, timeoutInterval: 10)
+    URLSession.shared.dataTask(with: request) { data, _, _ in
+      guard let data = data,
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let results = json["results"] as? [[String: Any]],
+            let storeVersion = results.first?["version"] as? String else {
+        reply("", false)
+        return
+      }
+      let updateAvailable = storeVersion.compare(installedVersion, options: .numeric) == .orderedDescending
+      reply(storeVersion, updateAvailable)
+    }.resume()
   }
 
   private func showStoreProductView(appStoreId: String) {

--- a/ios/in_app_update_flutter/Sources/in_app_update_flutter/InAppUpdateFlutterPlugin.swift
+++ b/ios/in_app_update_flutter/Sources/in_app_update_flutter/InAppUpdateFlutterPlugin.swift
@@ -39,26 +39,18 @@ public class InAppUpdateFlutterPlugin: NSObject, FlutterPlugin, SKStoreProductVi
       flutterResult = result
       showStoreProductView(appStoreId: appStoreId)
     case "checkUpdateIos":
-      checkUpdate(result: result)
+      let regionOverride = (call.arguments as? [String: Any])?["region"] as? String
+      checkUpdate(regionOverride: regionOverride, result: result)
     default:
       result(FlutterMethodNotImplemented)
     }
   }
 
-  private func checkUpdate(result: @escaping FlutterResult) {
+  private func checkUpdate(regionOverride: String?, result: @escaping FlutterResult) {
     let bundleId = Bundle.main.bundleIdentifier ?? ""
     let installedVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
 
-    // Region comes from the device's language & region settings as an ISO
-    // 3166-1 alpha-2 code (e.g. "us", "gb") — the same form the iTunes Lookup
-    // API expects, so no conversion table is needed. Without a region the API
-    // defaults to the US store, which would miss apps not listed there.
-    let regionCode: String
-    if #available(iOS 16, *) {
-      regionCode = Locale.current.region?.identifier.lowercased() ?? ""
-    } else {
-      regionCode = Locale.current.regionCode?.lowercased() ?? ""
-    }
+    let regionCode = Self.resolveRegion(override: regionOverride)
     let regionPath = regionCode.isEmpty ? "" : "/\(regionCode)"
 
     func reply(_ storeVersion: String, _ updateAvailable: Bool) {
@@ -93,6 +85,29 @@ public class InAppUpdateFlutterPlugin: NSObject, FlutterPlugin, SKStoreProductVi
         storeVersion.compare(installedVersion, options: .numeric) == .orderedDescending
       reply(storeVersion, updateAvailable)
     }.resume()
+  }
+
+  /// Resolves the ISO 3166-1 alpha-2 region used to scope the iTunes Lookup
+  /// URL, in order of preference:
+  ///
+  ///   1. An explicit `override` supplied by the caller (already alpha-2). Use
+  ///      this when the device region doesn't match the App Store storefront
+  ///      the app is published in (e.g. an expat or QA device).
+  ///   2. The device's language & region setting (`Locale.current`), already in
+  ///      the alpha-2 form the API expects — no conversion table needed.
+  ///
+  /// Without any region the API defaults to the US store, which would miss
+  /// apps not listed there.
+  static func resolveRegion(override: String?) -> String {
+    if let override = override?.trimmingCharacters(in: .whitespacesAndNewlines),
+       !override.isEmpty {
+      return override.lowercased()
+    }
+
+    if #available(iOS 16, *) {
+      return Locale.current.region?.identifier.lowercased() ?? ""
+    }
+    return Locale.current.regionCode?.lowercased() ?? ""
   }
 
   private func showStoreProductView(appStoreId: String) {

--- a/lib/in_app_update_flutter.dart
+++ b/lib/in_app_update_flutter.dart
@@ -40,10 +40,12 @@ class InAppUpdateFlutter {
   /// Returns an [AppUpdateInfoIos] with the installed version, the latest
   /// store version, and whether an update is available.
   ///
-  /// The lookup is automatically scoped to the device's region setting
-  /// (`Locale.current`), so no region parameter is needed.
-  Future<AppUpdateInfoIos> checkUpdateIos() {
-    return InAppUpdateFlutterPlatform.instance.checkUpdateIos();
+  /// By default the lookup is scoped to the device's region setting
+  /// (`Locale.current`). Pass [region] (an ISO 3166-1 alpha-2 code, e.g. `'us'`,
+  /// `'gb'`) to target a specific App Store region instead — useful when the
+  /// device region differs from the storefront the app is published in.
+  Future<AppUpdateInfoIos> checkUpdateIos({String? region}) {
+    return InAppUpdateFlutterPlatform.instance.checkUpdateIos(region: region);
   }
 
   /// Android: Checks whether an in-app update is available via Play Core.

--- a/lib/in_app_update_flutter.dart
+++ b/lib/in_app_update_flutter.dart
@@ -35,6 +35,17 @@ class InAppUpdateFlutter {
         .showUpdateForIos(appStoreId: appStoreId);
   }
 
+  /// iOS: Checks whether an update is available via the iTunes Lookup API.
+  ///
+  /// Returns an [AppUpdateInfoIos] with the installed version, the latest
+  /// store version, and whether an update is available.
+  ///
+  /// The lookup is automatically scoped to the device's region setting
+  /// (`Locale.current`), so no region parameter is needed.
+  Future<AppUpdateInfoIos> checkUpdateIos() {
+    return InAppUpdateFlutterPlatform.instance.checkUpdateIos();
+  }
+
   /// Android: Checks whether an in-app update is available via Play Core.
   ///
   /// Returns an [AppUpdateInfoAndroid] containing update metadata such as

--- a/lib/src/method_channel/in_app_update_flutter_method_channel.dart
+++ b/lib/src/method_channel/in_app_update_flutter_method_channel.dart
@@ -33,9 +33,10 @@ class MethodChannelInAppUpdateFlutter extends InAppUpdateFlutterPlatform {
   }
 
   @override
-  Future<AppUpdateInfoIos> checkUpdateIos() async {
+  Future<AppUpdateInfoIos> checkUpdateIos({String? region}) async {
     final result = await _methodChannel.invokeMapMethod<String, dynamic>(
       'checkUpdateIos',
+      region != null ? {'region': region} : null,
     );
     return AppUpdateInfoIos.fromMap(result ?? const {});
   }

--- a/lib/src/method_channel/in_app_update_flutter_method_channel.dart
+++ b/lib/src/method_channel/in_app_update_flutter_method_channel.dart
@@ -33,6 +33,14 @@ class MethodChannelInAppUpdateFlutter extends InAppUpdateFlutterPlatform {
   }
 
   @override
+  Future<AppUpdateInfoIos> checkUpdateIos() async {
+    final result = await _methodChannel.invokeMapMethod<String, dynamic>(
+      'checkUpdateIos',
+    );
+    return AppUpdateInfoIos.fromMap(result ?? const {});
+  }
+
+  @override
   Future<AppUpdateInfoAndroid> checkUpdateAndroid() async {
     final result = await _methodChannel.invokeMapMethod<String, dynamic>(
       'checkForUpdateAndroid',

--- a/lib/src/models/app_update_info_ios.dart
+++ b/lib/src/models/app_update_info_ios.dart
@@ -1,0 +1,36 @@
+/// Information about an iOS app update retrieved from the App Store.
+class AppUpdateInfoIos {
+  /// The latest version available on the App Store.
+  final String storeVersion;
+
+  /// The currently installed version of the app.
+  final String installedVersion;
+
+  /// Whether an update is available (store version > installed version).
+  final bool updateAvailable;
+
+  /// The bundle ID used to look up the App Store listing.
+  final String bundleId;
+
+  const AppUpdateInfoIos({
+    required this.storeVersion,
+    required this.installedVersion,
+    required this.updateAvailable,
+    required this.bundleId,
+  });
+
+  /// Creates an [AppUpdateInfoIos] from a platform channel map.
+  factory AppUpdateInfoIos.fromMap(Map<String, dynamic> map) {
+    return AppUpdateInfoIos(
+      storeVersion: map['storeVersion'] as String? ?? '',
+      installedVersion: map['installedVersion'] as String? ?? '',
+      updateAvailable: map['updateAvailable'] as bool? ?? false,
+      bundleId: map['bundleId'] as String? ?? '',
+    );
+  }
+
+  @override
+  String toString() =>
+      'AppUpdateInfoIos(bundleId: $bundleId, installed: $installedVersion, '
+      'store: $storeVersion, updateAvailable: $updateAvailable)';
+}

--- a/lib/src/models/models.dart
+++ b/lib/src/models/models.dart
@@ -1,4 +1,5 @@
 export 'app_update_info_android.dart';
+export 'app_update_info_ios.dart';
 export 'install_state_android.dart';
 export 'install_status_android.dart';
 export 'update_availability_android.dart';

--- a/lib/src/platform_interface/in_app_update_flutter_platform_interface.dart
+++ b/lib/src/platform_interface/in_app_update_flutter_platform_interface.dart
@@ -49,6 +49,16 @@ abstract class InAppUpdateFlutterPlatform extends PlatformInterface {
     throw UnimplementedError('showUpdateForIos() has not been implemented.');
   }
 
+  /// iOS: Checks whether an update is available via the iTunes Lookup API.
+  ///
+  /// Queries the App Store for the latest published version and compares it
+  /// against the currently installed version. The lookup is scoped to the
+  /// device's region setting (`Locale.current`), so no region needs to be
+  /// passed.
+  Future<AppUpdateInfoIos> checkUpdateIos() {
+    throw UnimplementedError('checkUpdateIos() has not been implemented.');
+  }
+
   /// Android: Checks whether an in-app update is available via Play Core.
   ///
   /// Returns an [AppUpdateInfoAndroid] containing update metadata such as

--- a/lib/src/platform_interface/in_app_update_flutter_platform_interface.dart
+++ b/lib/src/platform_interface/in_app_update_flutter_platform_interface.dart
@@ -53,9 +53,12 @@ abstract class InAppUpdateFlutterPlatform extends PlatformInterface {
   ///
   /// Queries the App Store for the latest published version and compares it
   /// against the currently installed version. The lookup is scoped to the
-  /// device's region setting (`Locale.current`), so no region needs to be
-  /// passed.
-  Future<AppUpdateInfoIos> checkUpdateIos() {
+  /// device's region setting (`Locale.current`) by default.
+  ///
+  /// Pass [region] (an ISO 3166-1 alpha-2 code, e.g. `'us'`, `'gb'`) to target a
+  /// specific App Store region instead — useful when the device region differs
+  /// from the storefront the app is published in.
+  Future<AppUpdateInfoIos> checkUpdateIos({String? region}) {
     throw UnimplementedError('checkUpdateIos() has not been implemented.');
   }
 

--- a/test/in_app_update_flutter_method_channel_test.dart
+++ b/test/in_app_update_flutter_method_channel_test.dart
@@ -98,6 +98,30 @@ void main() {
         expect(info.bundleId, 'com.example.app');
       });
 
+      test('omits region argument when not provided', () async {
+        Object? invokedArgs;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(methodChannel, (call) async {
+          invokedArgs = call.arguments;
+          return null;
+        });
+
+        await plugin.checkUpdateIos();
+        expect(invokedArgs, isNull);
+      });
+
+      test('forwards region override as a channel argument', () async {
+        Object? invokedArgs;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(methodChannel, (call) async {
+          invokedArgs = call.arguments;
+          return null;
+        });
+
+        await plugin.checkUpdateIos(region: 'gb');
+        expect(invokedArgs, {'region': 'gb'});
+      });
+
       test('defaults to empty/false when channel returns null', () async {
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(methodChannel, (call) async => null);

--- a/test/in_app_update_flutter_method_channel_test.dart
+++ b/test/in_app_update_flutter_method_channel_test.dart
@@ -76,6 +76,52 @@ void main() {
       });
     });
 
+    group('checkUpdateIos', () {
+      test('calls checkUpdateIos and deserializes response', () async {
+        String? invokedMethod;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(methodChannel, (call) async {
+          invokedMethod = call.method;
+          return {
+            'storeVersion': '2.1.0',
+            'installedVersion': '2.0.0',
+            'updateAvailable': true,
+            'bundleId': 'com.example.app',
+          };
+        });
+
+        final info = await plugin.checkUpdateIos();
+        expect(invokedMethod, 'checkUpdateIos');
+        expect(info.storeVersion, '2.1.0');
+        expect(info.installedVersion, '2.0.0');
+        expect(info.updateAvailable, true);
+        expect(info.bundleId, 'com.example.app');
+      });
+
+      test('defaults to empty/false when channel returns null', () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(methodChannel, (call) async => null);
+
+        final info = await plugin.checkUpdateIos();
+        expect(info.storeVersion, '');
+        expect(info.installedVersion, '');
+        expect(info.updateAvailable, false);
+        expect(info.bundleId, '');
+      });
+
+      test('propagates platform errors', () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(methodChannel, (call) async {
+          throw PlatformException(code: 'LOOKUP_ERROR');
+        });
+
+        expect(
+          () => plugin.checkUpdateIos(),
+          throwsA(isA<PlatformException>()),
+        );
+      });
+    });
+
     group('checkUpdateAndroid', () {
       test('calls checkForUpdateAndroid and deserializes response', () async {
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger

--- a/test/in_app_update_flutter_method_channel_test.dart
+++ b/test/in_app_update_flutter_method_channel_test.dart
@@ -109,6 +109,26 @@ void main() {
         expect(info.bundleId, '');
       });
 
+      test('returns updateAvailable false on lookup failure (not found)',
+          () async {
+        // Native side returns this payload when the app isn't found / the
+        // lookup fails — the contract is to report no update, never throw.
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(methodChannel, (call) async {
+          return {
+            'storeVersion': '',
+            'installedVersion': '1.0.0',
+            'updateAvailable': false,
+            'bundleId': 'com.example.app',
+          };
+        });
+
+        final info = await plugin.checkUpdateIos();
+        expect(info.updateAvailable, false);
+        expect(info.storeVersion, '');
+        expect(info.installedVersion, '1.0.0');
+      });
+
       test('propagates platform errors', () async {
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(methodChannel, (call) async {

--- a/test/in_app_update_flutter_test.dart
+++ b/test/in_app_update_flutter_test.dart
@@ -20,6 +20,16 @@ class _MockPlatform extends InAppUpdateFlutterPlatform {
   }
 
   @override
+  Future<AppUpdateInfoIos> checkUpdateIos() async {
+    return const AppUpdateInfoIos(
+      storeVersion: '2.0.0',
+      installedVersion: '1.0.0',
+      updateAvailable: true,
+      bundleId: 'com.example.app',
+    );
+  }
+
+  @override
   Future<AppUpdateInfoAndroid> checkUpdateAndroid() async {
     return const AppUpdateInfoAndroid(
       updateAvailability: UpdateAvailabilityAndroid.updateAvailable,
@@ -109,6 +119,13 @@ void main() {
         );
       });
 
+      test('checkUpdateIos throws UnimplementedError', () {
+        expect(
+          () => platform.checkUpdateIos(),
+          throwsA(isA<UnimplementedError>()),
+        );
+      });
+
       test('checkUpdateAndroid throws UnimplementedError', () {
         expect(
           () => platform.checkUpdateAndroid(),
@@ -153,6 +170,17 @@ void main() {
         await InAppUpdateFlutterPlatform.instance
             .showUpdateForIos(appStoreId: '544007664');
         expect(mock.lastAppStoreId, '544007664');
+      });
+
+      test('checkUpdateIos returns expected info', () async {
+        final mock = _MockPlatform();
+        InAppUpdateFlutterPlatform.instance = mock;
+
+        final info = await InAppUpdateFlutterPlatform.instance.checkUpdateIos();
+        expect(info.storeVersion, '2.0.0');
+        expect(info.installedVersion, '1.0.0');
+        expect(info.updateAvailable, isTrue);
+        expect(info.bundleId, 'com.example.app');
       });
 
       test('checkUpdateAndroid returns expected info', () async {

--- a/test/in_app_update_flutter_test.dart
+++ b/test/in_app_update_flutter_test.dart
@@ -19,8 +19,11 @@ class _MockPlatform extends InAppUpdateFlutterPlatform {
     lastAppStoreId = appStoreId;
   }
 
+  String? lastRegion;
+
   @override
-  Future<AppUpdateInfoIos> checkUpdateIos() async {
+  Future<AppUpdateInfoIos> checkUpdateIos({String? region}) async {
+    lastRegion = region;
     return const AppUpdateInfoIos(
       storeVersion: '2.0.0',
       installedVersion: '1.0.0',
@@ -181,6 +184,14 @@ void main() {
         expect(info.installedVersion, '1.0.0');
         expect(info.updateAvailable, isTrue);
         expect(info.bundleId, 'com.example.app');
+      });
+
+      test('checkUpdateIos forwards the region override', () async {
+        final mock = _MockPlatform();
+        InAppUpdateFlutterPlatform.instance = mock;
+
+        await InAppUpdateFlutterPlatform.instance.checkUpdateIos(region: 'gb');
+        expect(mock.lastRegion, 'gb');
       });
 
       test('checkUpdateAndroid returns expected info', () async {


### PR DESCRIPTION
Closes #16

## Summary

Adds an iOS equivalent of the Android `checkUpdateAndroid()` method, so callers can know whether an App Store update is available *before* triggering any UI.

`checkUpdateIos()` queries the [iTunes Lookup API](https://itunes.apple.com/lookup) for the latest published version and compares it against the installed version. It is implemented **natively in the existing Swift plugin** (over the method channel, mirroring the Android side) — **no new Dart packages**.

```dart
final plugin = InAppUpdateFlutter();

final info = await plugin.checkUpdateIos();
// info.installedVersion — version currently installed
// info.storeVersion     — latest version on the App Store
// info.updateAvailable  — true if storeVersion > installedVersion

if (info.updateAvailable) {
  await plugin.showUpdateForIos(appStoreId: '123456');
}
```

## Why native (vs. a pure-Dart implementation)

Everything needed is already available natively on iOS, so this avoids adding dependencies:

| Need | Native Swift |
|---|---|
| Bundle ID | `Bundle.main.bundleIdentifier` |
| Installed version | `Bundle.main.infoDictionary["CFBundleShortVersionString"]` |
| Store region | `Locale.current.region?.identifier` (iOS 16+) / `regionCode` |
| HTTP request | `URLSession` (10s timeout) |
| JSON parsing | `JSONSerialization` (targets `results[0].version`) |
| Version compare | `String.compare(_:options: .numeric)` |

## Region handling

The lookup is scoped to the **device's region setting** via `Locale.current`, which already returns an ISO 3166-1 **alpha-2** code (e.g. `us`, `gb`, `in`) — exactly what the iTunes Lookup API expects, so no lookup table or conversion is needed. This fixes two failure modes of a developer-passed region (hardcoding the wrong store, or defaulting to the US store for apps not listed there), so the `iosAppStoreRegion` parameter is **removed from the public API**. No permission prompt, no `Info.plist` entries — it's the same API every app uses for localization.

## Changes

* Add `checkUpdateIos` case to `InAppUpdateFlutterPlugin` (native `URLSession` + `JSONSerialization`, `.numeric` version compare, device region via `Locale.current`, `FlutterResult` dispatched on the main thread)
* Add `AppUpdateInfoIos` model (`storeVersion`, `installedVersion`, `updateAvailable`, `bundleId`) with a `fromMap` factory
* Wire `checkUpdateIos()` through the existing **platform interface**, method-channel implementation, and public API (platform interface kept intact)
* Drop the `iosAppStoreRegion` parameter from the public API
* Remove dependencies: `package_info_plus`, `pub_semver`
* Add Dart method-channel tests (deserialize / null-default / error propagation) and a delegation test
* Document `checkUpdateIos` in the README iOS Usage section

## Notes

* `.numeric` string comparison handles non-semver App Store versions like `1.0` or `2.3.4.5` (which `pub_semver` would throw on).
* On lookup failure (network error, missing/invalid listing) the method returns `updateAvailable: false` with an empty `storeVersion` rather than throwing — see the open question in #16 if a different fallback is preferred.

## Test status

`32/32` Dart tests passing · `flutter analyze` clean · `dart format` clean · example iOS app builds (`flutter build ios --simulator`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `checkUpdateIos()` to perform iOS update checks and return store/installed version, availability, and bundle identifier.
  * iOS update checks automatically use the device’s App Store region via the native iTunes Lookup API—no region parameter required.
* **Bug Fixes**
  * Improved iOS store-update prompt handling with stricter argument validation and clearer errors for invalid inputs.
* **Documentation**
  * Updated the README with a new iOS “Check for an update” section and detailed returned fields.
* **Tests**
  * Added iOS update-check test coverage, including default fallbacks and error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

