### PR TITLE
fix(ios): resolve STORE_NOT_LOADED when showing App Store update (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.0.0
+
+- **Fixed iOS `showUpdateForIos` always failing with `STORE_NOT_LOADED`.** The App Store ID is now passed to StoreKit as an `NSNumber` (as required by `SKStoreProductParameterITunesItemIdentifier`) instead of a `String`, so the App Store overlay loads correctly.
+- Fixed the App Store overlay failing to present because the view controller was captured (and often `nil`) at plugin registration. It is now resolved at call time via the active window scene.
+- Added distinct error codes for clearer diagnostics: `INVALID_APP_STORE_ID` (non-numeric ID) and `NO_VIEW_CONTROLLER` (nothing available to present from), separate from `STORE_NOT_LOADED`.
+- **BREAKING:** Raised the minimum supported iOS version from 12.0 to 13.0.
+
 ## 2.0.3
 
 - Fixed README screenshots not rendering on pub.dev by using absolute GitHub raw URLs

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add the package to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  in_app_update_flutter: ^2.0.3
+  in_app_update_flutter: ^3.0.0
 ```
 
 Then run:
@@ -60,7 +60,7 @@ await InAppUpdateFlutter().showUpdateForIos(appStoreId: '1234567890');
 2. The numeric portion after `id` is your App Store ID.
 
 **iOS notes:**
-- Requires iOS 12.0 or later
+- Requires iOS 13.0 or later
 - Does not work on simulators
 - Not supported in TestFlight builds — test on a real device using a development or App Store build
 

--- a/example/ios/RunnerTests/RunnerTests.swift
+++ b/example/ios/RunnerTests/RunnerTests.swift
@@ -20,6 +20,35 @@ class RunnerTests: XCTestCase {
     waitForExpectations(timeout: 1)
   }
 
+  func testShowStoreUpdateIosWithNonNumericId() {
+    let plugin = InAppUpdateFlutterPlugin()
+
+    let call = FlutterMethodCall(methodName: "showStoreUpdateIos", arguments: ["appStoreId": "not-a-number"])
+
+    let resultExpectation = expectation(description: "result block must be called.")
+    plugin.handle(call) { result in
+      // A non-numeric appStoreId must be rejected before reaching StoreKit.
+      let error = result as? FlutterError
+      XCTAssertEqual(error?.code, "INVALID_APP_STORE_ID")
+      resultExpectation.fulfill()
+    }
+    waitForExpectations(timeout: 1)
+  }
+
+  func testShowStoreUpdateIosWithoutAppStoreId() {
+    let plugin = InAppUpdateFlutterPlugin()
+
+    let call = FlutterMethodCall(methodName: "showStoreUpdateIos", arguments: nil)
+
+    let resultExpectation = expectation(description: "result block must be called.")
+    plugin.handle(call) { result in
+      // Missing appStoreId fails the argument binding and is not implemented.
+      XCTAssertEqual(result as? NSObject, FlutterMethodNotImplemented as NSObject)
+      resultExpectation.fulfill()
+    }
+    waitForExpectations(timeout: 1)
+  }
+
   func testUnknownMethod() {
     let plugin = InAppUpdateFlutterPlugin()
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -37,6 +37,9 @@ class IosUpdateExample extends StatelessWidget {
         child: ElevatedButton(
           onPressed: () async {
             try {
+              // Public App Store ID used only for this demo (YouTube).
+              // Replace with your own app's numeric App Store ID in a real
+              // integration.
               await InAppUpdateFlutter()
                   .showUpdateForIos(appStoreId: '544007664');
             } catch (e) {

--- a/ios/in_app_update_flutter.podspec
+++ b/ios/in_app_update_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'in_app_update_flutter'
-  s.version          = '2.0.3'
+  s.version          = '3.0.0'
   s.summary          = 'In-app updates for iOS (StoreKit) and Android (Play Core).'
   s.description      = <<-DESC
 A Flutter plugin to prompt users for in-app updates using StoreKit on iOS and the Play Core API on Android, supporting both immediate and flexible update flows.
@@ -15,7 +15,7 @@ A Flutter plugin to prompt users for in-app updates using StoreKit on iOS and th
   s.source           = { :path => '.' }
   s.source_files = 'in_app_update_flutter/Sources/in_app_update_flutter/**/*.swift'
   s.dependency 'Flutter'
-  s.platform = :ios, '12.0'
+  s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/ios/in_app_update_flutter/Package.swift
+++ b/ios/in_app_update_flutter/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "in_app_update_flutter",
     platforms: [
-        .iOS(.v12)
+        .iOS(.v13)
     ],
     products: [
         .library(name: "in-app-update-flutter", targets: ["in_app_update_flutter"])

--- a/ios/in_app_update_flutter/Sources/in_app_update_flutter/InAppUpdateFlutterPlugin.swift
+++ b/ios/in_app_update_flutter/Sources/in_app_update_flutter/InAppUpdateFlutterPlugin.swift
@@ -4,13 +4,28 @@ import StoreKit
 
 public class InAppUpdateFlutterPlugin: NSObject, FlutterPlugin, SKStoreProductViewControllerDelegate {
   var flutterResult: FlutterResult?
-  var controller: UIViewController?
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(name: "in_app_update_flutter", binaryMessenger: registrar.messenger())
     let instance = InAppUpdateFlutterPlugin()
-    instance.controller = UIApplication.shared.delegate?.window??.rootViewController
     registrar.addMethodCallDelegate(instance, channel: channel)
+  }
+
+  /// Resolves the view controller to present from at call time. Capturing the
+  /// root view controller at registration is unreliable: on app launch the
+  /// window/rootViewController may not be set yet (especially with scene-based
+  /// lifecycles), leaving it nil for the lifetime of the plugin.
+  private func topViewController() -> UIViewController? {
+    let keyWindow = UIApplication.shared.connectedScenes
+      .compactMap { $0 as? UIWindowScene }
+      .flatMap { $0.windows }
+      .first { $0.isKeyWindow }
+
+    var top = keyWindow?.rootViewController
+    while let presented = top?.presentedViewController {
+      top = presented
+    }
+    return top
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
@@ -25,10 +40,18 @@ public class InAppUpdateFlutterPlugin: NSObject, FlutterPlugin, SKStoreProductVi
   }
 
   private func showStoreProductView(appStoreId: String) {
+    // StoreKit requires the iTunes item identifier as an NSNumber. Passing a
+    // String causes loadProduct(withParameters:) to silently fail (loaded == false,
+    // error == nil), which surfaces as STORE_NOT_LOADED.
+    guard let appStoreIdNumber = Int(appStoreId) else {
+      flutterResult?(FlutterError(code: "INVALID_APP_STORE_ID", message: "appStoreId must be a numeric value", details: appStoreId))
+      return
+    }
+
     let productViewController = SKStoreProductViewController()
     productViewController.delegate = self
 
-    let parameters = [SKStoreProductParameterITunesItemIdentifier : appStoreId]
+    let parameters = [SKStoreProductParameterITunesItemIdentifier : NSNumber(value: appStoreIdNumber)]
 
     productViewController.loadProduct(withParameters: parameters) { loaded, error in
       if let error = error {
@@ -36,12 +59,18 @@ public class InAppUpdateFlutterPlugin: NSObject, FlutterPlugin, SKStoreProductVi
         return
       }
 
-      if loaded, let vc = self.controller {
-        vc.present(productViewController, animated: true) {
-          self.flutterResult?(nil)
-        }
-      } else {
+      guard loaded else {
         self.flutterResult?(FlutterError(code: "STORE_NOT_LOADED", message: "Could not load product", details: nil))
+        return
+      }
+
+      guard let vc = self.topViewController() else {
+        self.flutterResult?(FlutterError(code: "NO_VIEW_CONTROLLER", message: "No view controller available to present the App Store overlay", details: nil))
+        return
+      }
+
+      vc.present(productViewController, animated: true) {
+        self.flutterResult?(nil)
       }
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: in_app_update_flutter
 description: "A Flutter plugin to prompt users for in-app updates using StoreKit on iOS and Play Core API on Android."
-version: 2.0.3
+version: 3.0.0
 repository: https://github.com/axions-org/in_app_update_flutter.git
 homepage: https://github.com/axions-org/in_app_update_flutter
 issue_tracker: https://github.com/axions-org/in_app_update_flutter/issues


### PR DESCRIPTION
## Summary

Fixes #29 — iOS `showUpdateForIos` always failed with `PlatformException(STORE_NOT_LOADED, ...)` and the App Store overlay never appeared.

Two distinct bugs produced the same `STORE_NOT_LOADED` error:

1. **App Store ID passed as `String`.** Apple's `SKStoreProductParameterITunesItemIdentifier` requires an `NSNumber`. Given a `String`, `loadProduct(withParameters:)` silently fails (`loaded == false`, `error == nil`) → `STORE_NOT_LOADED`. Now converted to `NSNumber`. (Verified against the [StoreKit docs](https://developer.apple.com/documentation/storekit/skstoreproductparameteritunesitemidentifier).)
2. **Presenting view controller captured at registration.** It was read from `UIApplication.shared.delegate?.window??.rootViewController` in `register()`, which is typically `nil` at app launch with scene-based lifecycles — so even after the product loaded, presentation fell into the same `STORE_NOT_LOADED` branch. Now resolved at call time via the active `UIWindowScene`.

## Changes

- Pass `appStoreId` to StoreKit as `NSNumber`.
- Resolve the top view controller at call time instead of caching at registration.
- Add distinct error codes: `INVALID_APP_STORE_ID` (non-numeric ID) and `NO_VIEW_CONTROLLER`, separate from `STORE_NOT_LOADED`.
- **BREAKING:** raise minimum iOS from 12.0 → 13.0 (required for the scene-based window lookup; the example app already targeted 13.0).
- Bump version 2.0.3 → 3.0.0 (pubspec, podspec, README).
- Add iOS unit tests for the validation paths and a clarifying comment on the example's demo App Store ID.

## Testing

- New XCTest cases cover `INVALID_APP_STORE_ID` and the missing-arg path.
- The overlay itself must be verified on a **physical device** — `SKStoreProductViewController` does not work on the Simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)