### PR TITLE
ci: add Android and iOS build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,31 @@ jobs:
           channel: stable
       - run: flutter pub get
       - run: flutter pub publish --dry-run
+
+  build-android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+        working-directory: example
+      - run: flutter build apk --debug
+        working-directory: example
+
+  build-ios:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+        working-directory: example
+      - run: flutter build ios --no-codesign --debug
+        working-directory: example


### PR DESCRIPTION
## Summary

Adds the two missing platform build jobs to `ci.yml` so a change that breaks the Android/iOS build is caught on PRs.

- **build-android** (`ubuntu-latest`): sets up Java 17 (the example app targets Java 17), `flutter pub get` + `flutter build apk --debug` in `example/`.
- **build-ios** (`macos-latest`): `flutter pub get` + `flutter build ios --no-codesign --debug` in `example/`.

Both run on PRs to `production` (existing workflow trigger).

## Testing

Both builds were run locally and succeeded:
- `flutter build apk --debug` → `✓ Built build/app/outputs/flutter-apk/app-debug.apk`
- `flutter build ios --no-codesign --debug` → `✓ Built build/ios/iphoneos/Runner.app`

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)